### PR TITLE
Fix display of single item of a select

### DIFF
--- a/Zikula/Module/ProfileModule/Resources/views/plugins/function.duditemdisplay.php
+++ b/Zikula/Module/ProfileModule/Resources/views/plugins/function.duditemdisplay.php
@@ -176,12 +176,16 @@ function smarty_function_duditemdisplay($params, Zikula_View $view)
     } elseif ($item['prop_displaytype'] == 4) {
         // select
         $options = ModUtil::apiFunc(ProfileConstant::MODNAME, 'dud', 'getoptions', array('item' => $item));
-
         $output = array();
-        foreach ((array)$uservalue as $id) {
-            if (isset($options[$id])) {
-                $output[] = $options[$id];
+        
+        if(is_array($uservalue)) {
+            foreach ((array)$uservalue as $id) {
+                if (isset($options[$id])) {
+                    $output[] = $options[$id];
+                }
             }
+        } else {
+            $output[] = $options[$uservalue];
         }
 
     } elseif (!empty($uservalue) && $item['prop_displaytype'] == 5) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| License | MIT |

Pb.: I have added a dud field (single dropdown list) and I can not see the item in the profile view.

Sol.: I have changed the item display plugin to authorize the value of a single select to be rendered.
